### PR TITLE
Correct a typo in _locale_notify_command variable

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -25,6 +25,6 @@ locale_configuration_file: "{{ _locale_configuration_file[ansible_os_family] | d
 
 _locale_notify_command:
   default: localectl set-locale LANG={{ locale_lang }}
-  Debian: update-local LANG={{ locale_lang }}
+  Debian: update-locale LANG={{ locale_lang }}
 
 locale_notify_command: "{{ _locale_notify_command[ansible_os_family] | default(_locale_notify_command['default'] ) }}"


### PR DESCRIPTION
Correct a typo in `_locale_notify_command` variable for Debian specific execution.
The command should be `update-locale` instead of `update-local`.

Anyway, as of Debian 11, `localectl` is also present.